### PR TITLE
Create a draft pull request

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -410,7 +410,8 @@ class RequestManager:
             req.add_header("Authorization", "bearer " +
                     self.oauthtoken)
         req.add_header("Content-Type", "application/json")
-        req.add_header("Accept", "application/vnd.github.v3+json")
+        req.add_header("Accept",
+            "application/vnd.github.v3.shadow-cat-preview+json")
         req.add_header("Content-Length", str(len(body) if body else 0))
         req.get_method = lambda: method.upper()
         debugf('{}', req.get_full_url())
@@ -1476,6 +1477,10 @@ class PullCmd (IssueCmd):
                 action='store_true', default=False,
                 help="force the push git operation (use with "
                 "care!)")
+            parser.add_argument('-d', '--draft',
+                action='store_true', default=False,
+                help="create a draft pull request")
+
         @classmethod
         def run(cls, parser, args):
             head_ref, head_name, remote_head, base, gh_head = \
@@ -1487,10 +1492,11 @@ class PullCmd (IssueCmd):
             (title, body) = split_titled_message(msg)
             cls.push(head_name or head_ref, remote_head,
                     force=args.force_push)
-            infof("Creating pull request from branch {} to {}:{}",
+            infof("Creating pull request{} from branch {} to {}:{}",
+                    "(draft)" if args.draft else "",
                     remote_head, config.upstream, base)
             pull = req.post(cls.url(), head=gh_head, base=base,
-                    title=title, body=body)
+                    title=title, body=body, draft=args.draft)
             IssueCmd.UpdateCmd._do_update(pull['number'], args.labels,
                     args.assignee, args.milestone)
             cls.print_issue_summary(pull)

--- a/man.rst
+++ b/man.rst
@@ -311,6 +311,11 @@ COMMANDS
     \-f, --force-push
       Force the push operations. Use with care!
 
+    \-d, --draft
+      Create a draft pull request. Draft pull requests cannot be merged,
+      and code owners are not automatically requested to review draft pull
+      requests.
+
   `attach` ISSUE [HEAD]
     Convert the issue identified by **ISSUE** to a pull request by attaching
     commits to it. The branch (or git ref) where your changes are

--- a/relnotes/pull-draft.feature.md
+++ b/relnotes/pull-draft.feature.md
@@ -1,0 +1,3 @@
+### Create draft pull request
+
+* `git-hub pull new` accepts `--draft` or `-d` to create a draft pull request.


### PR DESCRIPTION
When you create a pull request, you can choose to create a pull request that
is ready for review or a draft pull request. Draft pull requests cannot be
merged, and code owners are not automatically requested to review draft pull
requests.