### PR TITLE
Add support for pull request template

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1432,6 +1432,20 @@ class PullUtil (IssueUtil):
         infof('Fetching {} from {}', ref, url)
         git_quiet(1, 'fetch', '--', url, ref)
 
+    # Join the template information to the body of the pull request.
+    @classmethod
+    def join_template(cls, body):
+        fname = os.path.join(git_dir(), 'PULL_REQUEST_TEMPLATE.md')
+        if os.path.exists(fname):
+            try:
+                file = open(fname, "r")
+                template = file.read()
+                return template + "\n\n" + body
+            except EnvironmentError as e:
+                die("Error reading pull request template information "
+                    "file '{}': {}", fname, e)
+        return body
+
 # `git hub pull` command implementation
 class PullCmd (IssueCmd):
 
@@ -1515,6 +1529,7 @@ class PullCmd (IssueCmd):
                 msg = cls.editor(cls.get_default_branch_msg(
                         head_ref, head_name))
             (title, body) = split_titled_message(msg)
+            body = cls.join_template(body)
             cls.push(head_name or head_ref, remote_head,
                     force=args.force_push)
             infof("Creating pull request from branch {} to {}:{}",

--- a/git-hub
+++ b/git-hub
@@ -427,7 +427,7 @@ class RequestManager:
     # Open an URL in an authenticated manner using the specified HTTP
     # method. It also add other convenience headers, like Content-Type,
     # Accept (both to json) and Content-Length).
-    def auth_urlopen(self, url, method, data):
+    def auth_urlopen(self, url, method, data, media_type):
         req = urllib2.Request(url, _encode(data))
         if self.basic_auth:
             req.add_header("Authorization", self.basic_auth)
@@ -435,7 +435,10 @@ class RequestManager:
             req.add_header("Authorization", "bearer " +
                     self.oauthtoken)
         req.add_header("Content-Type", "application/json")
-        req.add_header("Accept", "application/vnd.github.v3+json")
+        if media_type is None:
+            req.add_header("Accept", "application/vnd.github.v3+json")
+        else:
+            req.add_header("Accept", media_type)
         req.add_header("Content-Length", str(len(data) if data else 0))
         req.get_method = lambda: method.upper()
         debugf('{}', req.get_full_url())
@@ -473,7 +476,7 @@ class RequestManager:
     # uppercase), and args/kwargs are data to be sent to the client. Only
     # one can be specified at a time and they are serialized as json (args
     # as a json list and kwargs as a json dictionary/object).
-    def json_req(self, url, method, *args, **kwargs):
+    def json_req(self, url, method, media_type, *args, **kwargs):
         url = self.base_url + url
         if method.upper() in ('POST', 'PATCH', 'PUT'):
             body = self.dump(*args, **kwargs)
@@ -484,7 +487,7 @@ class RequestManager:
         prev_data = None
         while url:
             debugf("Request: {} {}\n{}", method, url, body)
-            res = self.auth_urlopen(url, method, body)
+            res = self.auth_urlopen(url, method, body, media_type)
             data = res.read()
             debugf("Response:\n{}", _decode(data))
             if data:
@@ -507,8 +510,8 @@ class RequestManager:
 # methods get bind with the last value of method ('delete') in this case, which
 # is not only what we want, is also very dangerous.
 def make_method(method):
-    return lambda self, url, *args, **kwargs: \
-        self.json_req(url, method, *args, **kwargs)
+    return lambda self, url, media_type=None, *args, **kwargs: \
+        self.json_req(url, method, media_type, *args, **kwargs)
 for method in ('OPTIONS', 'HEAD', 'GET', 'POST', 'PATCH', 'PUT', 'DELETE'):
     setattr(RequestManager, method.lower(), make_method(method))
 
@@ -1500,6 +1503,9 @@ class PullCmd (IssueCmd):
                     action='store_true', default=False,
                     help="force the push git operation (use with "
                     "care!)")
+            parser.add_argument('-d', '--draft',
+                    action='store_true', default=False,
+                    help="create a draft pull request")
         @classmethod
         def run(cls, parser, args):
             head_ref, head_name, remote_head, base, gh_head = \
@@ -1513,8 +1519,12 @@ class PullCmd (IssueCmd):
                     force=args.force_push)
             infof("Creating pull request from branch {} to {}:{}",
                     remote_head, config.upstream, base)
-            pull = req.post(cls.url(), head=gh_head, base=base,
-                    title=title, body=body)
+            # The draft feature is only available in a custom media type
+            media_type = None
+            if args.draft:
+                media_type = "application/vnd.github.shadow-cat-preview+json"
+            pull = req.post(cls.url(), media_type, head=gh_head, base=base,
+                    title=title, body=body, draft=args.draft)
             IssueCmd.UpdateCmd._do_update(pull['number'], args.labels,
                     args.assignee, args.milestone)
             cls.print_issue_summary(pull)

--- a/man.rst
+++ b/man.rst
@@ -311,6 +311,11 @@ COMMANDS
     \-f, --force-push
       Force the push operations. Use with care!
 
+    \-d, --draft
+      Create a draft pull request. Draft pull requests cannot be merged,
+      and code owners are not automatically requested to review draft pull
+      requests.
+
   `attach` ISSUE [HEAD]
     Convert the issue identified by **ISSUE** to a pull request by attaching
     commits to it. The branch (or git ref) where your changes are

--- a/relnotes/pull-draft.feature.md
+++ b/relnotes/pull-draft.feature.md
@@ -1,0 +1,3 @@
+### Create draft pull request
+
+* `git-hub pull new` accepts `--draft` or `-d` to create a draft pull request.


### PR DESCRIPTION
Example pull request template.

The pull request addresses:

- [] Add a pull request template file
- [] Read the content of the template into a string
- [] Join the template to the body of the pull request


Reads the content from the pull request template file
if the template is available and join it to the body
of the pull request.