### PR TITLE
Support issue and pull request templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 
 install: beaver install
 
-script: beaver make PYTHON=python2.7 all deb
+script: beaver make PYTHON=python all deb
 
 deploy:
     provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 
 install: beaver install
 
-script: beaver make PYTHON=python all deb
+script: beaver make PYTHON=python3 all deb
 
 deploy:
     provider: script

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ prefix ?= /usr/local
 # fall back to /etc, ignoring prefix
 sysconfdir ?= /etc
 
-export PYTHON ?= python2
+export PYTHON ?= python3
 RST2MAN ?= rst2man
 
 version ?= $(shell git describe --dirty 2> /dev/null | cut -b2-)
@@ -37,7 +37,7 @@ install: $(install-deps)
 	install -m 755 -D git-hub $(DESTDIR)$(prefix)/bin/git-hub
 	sed -i 's/^VERSION = "git-hub devel"$$/VERSION = "git-hub $(version)"/' \
 			$(DESTDIR)$(prefix)/bin/git-hub
-	sed -i 's|^#!/usr/bin/env python2$$|#!/usr/bin/env $(PYTHON)|' \
+	sed -i 's|^#!/usr/bin/env python3$$|#!/usr/bin/env $(PYTHON)|' \
 			$(DESTDIR)$(prefix)/bin/git-hub
 	install -m 644 -D git-hub.1 $(DESTDIR)$(prefix)/share/man/man1/git-hub.1
 	install -m 644 -D ftdetect.vim \

--- a/README.rst
+++ b/README.rst
@@ -151,8 +151,7 @@ Installation
 Dependencies
 ------------
 
-* Python_ 2.7 (3.x can be used too but you have to run the ``2to3`` tool to the
-  script first)
+* Python_ 3.x
 
 * Git_ >= 1.7.7 (if you use Ubuntu_ you can easily get the latest Git version
   using the `Git stable PPA`__)

--- a/deb/build
+++ b/deb/build
@@ -35,7 +35,7 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 	--vendor 'dunnhumby Germany GmbH' \
 	--license GPLv3 \
 	--category vcs \
-	--depends python2.7 \
+	--depends python3 \
 	--depends "git (>=1.7.7)" \
 	--deb-changelog "$changelog" \
 	install/usr=/ \

--- a/docker/build
+++ b/docker/build
@@ -2,4 +2,4 @@
 set -xeu
 
 apt-get update
-apt-get -y install python2.7 python-docutils
+apt-get -y install python3 python-docutils

--- a/generate-bash-completion
+++ b/generate-bash-completion
@@ -6,7 +6,7 @@ set -e
 # Based on the _git_svn completion function in git distribution's bash
 # completion.
 
-PYTHON=${PYTHON:-python2}
+PYTHON=${PYTHON:-python3}
 
 issue_arg_cmds="issue-show issue-update issue-comment issue-close pull-attach"
 pull_arg_cmds="pull-show pull-update pull-comment pull-close"

--- a/git-hub
+++ b/git-hub
@@ -308,6 +308,9 @@ def git_config(name, default=None, prefix=GIT_CONFIG_PREFIX, value=None, opts=()
 def git_dir():
     return git('rev-parse', '--git-dir')
 
+# Returns the absolute path of the top-level directory
+def git_toplevel_dir():
+    return git('rev-parse', '--show-toplevel')
 
 # Invokes the editor defined by git var GIT_EDITOR.
 #
@@ -1112,6 +1115,35 @@ class IssueUtil (object):
         comment = req.post(url, body=body)
         cls.print_comment(comment)
 
+    # Add the first template file content found to the message. If the message
+    # already exists, the template content is added between the title and the
+    # body of the existent message.
+    @classmethod
+    def add_template(cls, msg, template_names):
+        if not template_names:
+            return msg
+
+        directories = (git_toplevel_dir(),
+            os.path.join(git_toplevel_dir(), '.github'), git_dir())
+
+        template = None
+        for d, f in ((d, f) for d in directories for f in template_names):
+            path = os.path.join(d, f)
+            if os.path.exists(path):
+                try:
+                    file = open(path, "r")
+                    template = file.read()
+                    break
+                except EnvironmentError as e:
+                    die("Error reading template from path '{}': {}", path, e)
+        if template:
+            if msg:
+                (title, body) = split_titled_message(msg)
+                msg = title + "\n\n" + template + "\n" + body
+            else:
+                msg = template
+        return msg
+
 # `git hub issue` command implementation
 class IssueCmd (CmdGroup):
 
@@ -1199,9 +1231,17 @@ class IssueCmd (CmdGroup):
             parser.add_argument('-M', '--milestone', metavar='ID', type=int,
                     help="assign the milestone identified by the "
                     "number ID to the %s" % cls.name)
+            parser.add_argument('--no-template',
+                    action='store_true', default=False,
+                    help="Do not add the template content to the message")
         @classmethod
         def run(cls, parser, args):
-            msg = args.message or cls.editor()
+            msg = args.message
+            if not args.no_template:
+                templates = ('ISSUE_TEMPLATE', 'ISSUE_TEMPLATE.md')
+                msg = cls.add_template(msg, templates)
+            if not args.message:
+                msg = cls.editor(msg)
             (title, body) = split_titled_message(msg)
             issue = req.post(cls.url(), title=title, body=body,
                     assignee=args.assignee, labels=args.labels,
@@ -1501,8 +1541,13 @@ class PullCmd (IssueCmd):
                     cls.get_local_remote_heads(parser, args)
             msg = args.message
             if not msg:
-                msg = cls.editor(cls.get_default_branch_msg(
-                        head_ref, head_name))
+                msg = cls.get_default_branch_msg(head_ref, head_name)
+            if not args.no_template:
+                template_names = ('PULL_REQUEST_TEMPLATE',
+                        'PULL_REQUEST_TEMPLATE.md')
+                msg = cls.add_template(msg, template_names)
+            if not args.message:
+                msg = cls.editor(msg)
             (title, body) = split_titled_message(msg)
             cls.push(head_name or head_ref, remote_head,
                     force=args.force_push)

--- a/git-hub
+++ b/git-hub
@@ -42,12 +42,12 @@ import sys
 import time
 import json
 import base64
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import pprint
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import getpass
 import os.path
-import urlparse
+import urllib.parse
 import argparse
 import subprocess
 
@@ -145,7 +145,7 @@ class InterruptException (Exception):
 # Wrapper for raw_input to treat EOF as an empty input
 def user_input(*args, **kwargs):
     try:
-        return raw_input(*args, **kwargs)
+        return input(*args, **kwargs)
     except EOFError:
         sys.stdout.write('\n')
         return ''
@@ -360,7 +360,7 @@ class Config:
                 opts=['--bool']) == "true"
 
     def sanitize_url(self, name, url):
-        u = urlparse.urlsplit(url)
+        u = urllib.parse.urlsplit(url)
         name = GIT_CONFIG_PREFIX + name
         # interpret www.github.com/api/v4 as www.github.com, /api/v4
         if not u.hostname or not u.scheme:
@@ -374,7 +374,7 @@ class Config:
         netloc = u.hostname
         if u.port:
             netloc += ':' + u.port
-        return urlparse.urlunsplit((u.scheme, netloc,
+        return urllib.parse.urlunsplit((u.scheme, netloc,
                 u.path.rstrip('/'), u.query, u.fragment))
 
     def check(self, name):
@@ -428,7 +428,7 @@ class RequestManager:
     # method. It also add other convenience headers, like Content-Type,
     # Accept (both to json) and Content-Length).
     def auth_urlopen(self, url, method, data, media_type):
-        req = urllib2.Request(url, _encode(data))
+        req = urllib.request.Request(url, _encode(data))
         if self.basic_auth:
             req.add_header("Authorization", self.basic_auth)
         elif self.oauthtoken:
@@ -446,7 +446,7 @@ class RequestManager:
                 else:
                     debugf('{}: {}', *h)
         debugf('{}', req.data)
-        return urllib2.urlopen(req)
+        return urllib.request.urlopen(req)
 
     # Serialize args OR kwargs (they are mutually exclusive) as json.
     def dump(self, *args, **kwargs):
@@ -478,7 +478,7 @@ class RequestManager:
             body = self.dump(*args, **kwargs)
         else:
             body = None
-            url += '?' + urllib.urlencode(kwargs)
+            url += '?' + urllib.parse.urlencode(kwargs)
         data = None
         prev_data = None
         while url:
@@ -921,7 +921,7 @@ class CloneCmd (object):
         if '/' not in repo:
             repo = config.username + '/' + repo
         # Get just the owner/repo form from the full URL
-        url = urlparse.urlsplit(repo)
+        url = urllib.parse.urlsplit(repo)
         proj = '/'.join(url.path.split(':')[-1:][0].strip('/').split('/')[-2:])
         return (urltype, proj)
 
@@ -1009,8 +1009,8 @@ class IssueUtil (object):
 
     @classmethod
     def print_issue_summary(cls, issue):
-        infof(u'[{number}] {title} ({user[login]})\n{}{html_url}',
-                u' ' * (len(str(issue['number'])) + 3),
+        infof('[{number}] {title} ({user[login]})\n{}{html_url}',
+                ' ' * (len(str(issue['number'])) + 3),
                 **issue)
 
     @classmethod
@@ -1019,7 +1019,7 @@ class IssueUtil (object):
                 for l in issue.get('labels', [])])
         if issue['labels']:
             issue['labels'] += '\n'
-        infof(u"""
+        infof("""
 #{number}: {title}
 ================================================================================
 {name} is {state}, was reported by {user[login]} and has {comments} comment(s).
@@ -1030,14 +1030,14 @@ class IssueUtil (object):
 """,
                 **issue)
         if issue['comments'] > 0:
-            infof(u'Comments:')
+            infof('Comments:')
 
     @classmethod
-    def print_issue_comment(cls, comment, indent=u''):
+    def print_issue_comment(cls, comment, indent=''):
         body = comment['body']
         body = '\n'.join([indent+'    '+l for l in body.splitlines()])
-        infof(u'{0}On {created_at}, {user[login]}, commented:\n'
-                u'{0}<{html_url}>\n\n{1}\n', indent, body, **comment)
+        infof('{0}On {created_at}, {user[login]}, commented:\n'
+                '{0}<{html_url}>\n\n{1}\n', indent, body, **comment)
 
     @classmethod
     def merge_issue_comments(cls, comments, review_comments):
@@ -1064,14 +1064,14 @@ class IssueUtil (object):
         issue['comments'] += len(comments) + len(review_comments)
         cls.print_issue_header(issue)
         for c in cls.merge_issue_comments(comments, review_comments):
-            infof(u'{}\n', u'-' * 80)
+            infof('{}\n', '-' * 80)
             if 'diff_hunk' in c:
                 hunk = '\n'.join(c['diff_hunk'].splitlines()[-5:])
-                infof(u'diff --git a/{path} b/{path}\n'
-                        u'index {original_commit_id}..{commit_id}\n'
-                        u'--- a/{path}\n'
-                        u'+++ b/{path}\n'
-                        u'{0}\n',
+                infof('diff --git a/{path} b/{path}\n'
+                        'index {original_commit_id}..{commit_id}\n'
+                        '--- a/{path}\n'
+                        '+++ b/{path}\n'
+                        '{0}\n',
                         hunk, **c)
                 indent = '    '
                 cls.print_issue_comment(c, indent)
@@ -1083,9 +1083,9 @@ class IssueUtil (object):
     @classmethod
     def print_comment(cls, comment):
         body = comment['body']
-        infof(u'[{id}] {}{} ({user[login]})\n{html_url}', body[:60],
-                u'…' if len(body) > 60 else u'',
-                u' ' * (len(str(comment['id'])) + 3),
+        infof('[{id}] {}{} ({user[login]})\n{html_url}', body[:60],
+                '…' if len(body) > 60 else '',
+                ' ' * (len(str(comment['id'])) + 3),
                 **comment)
 
     @classmethod
@@ -1147,13 +1147,13 @@ class IssueCmd (CmdGroup):
             if args.created_by_me and args.assigned_to_me:
                 issues = [
                         i for i in issues
-                        if filter(i, 'assignee')
-                        or filter(i, 'user')]
+                        if list(filter(i, 'assignee'))
+                        or list(filter(i, 'user'))]
             elif args.created_by_me:
                 issues = [
-                        i for i in issues if filter(i, 'user')]
+                        i for i in issues if list(filter(i, 'user'))]
             elif args.assigned_to_me:
-                issues = [i for i in issues if filter(i, 'assignee')]
+                issues = [i for i in issues if list(filter(i, 'assignee'))]
             for issue in issues:
                 cls.print_issue_summary(issue)
 
@@ -2198,7 +2198,7 @@ def main():
 if __name__ == '__main__':
     try:
         main()
-    except urllib2.HTTPError as error:
+    except urllib.error.HTTPError as error:
         try:
             body = error.read()
             err = json.loads(body)
@@ -2226,7 +2226,7 @@ if __name__ == '__main__':
             errf('{}', body)
             sys.exit(3)
         sys.exit(4)
-    except urllib2.URLError as error:
+    except urllib.error.URLError as error:
         errf('Network error: {}', error)
         sys.exit(5)
     except KeyboardInterrupt:

--- a/git-hub
+++ b/git-hub
@@ -42,12 +42,10 @@ import sys
 import time
 import json
 import base64
-import urllib.request, urllib.parse, urllib.error
 import pprint
 import urllib.request, urllib.error, urllib.parse
 import getpass
 import os.path
-import urllib.parse
 import argparse
 import subprocess
 

--- a/git-hub
+++ b/git-hub
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # vim: set fileencoding=utf-8 :
 
 # Git command line interface to GitHub.

--- a/git-hub
+++ b/git-hub
@@ -48,6 +48,7 @@ import getpass
 import os.path
 import argparse
 import subprocess
+from functools import partial
 
 # Output levels according to user selected verbosity
 DEBUG = 3
@@ -1134,24 +1135,22 @@ class IssueCmd (CmdGroup):
                             cls.name))
         @classmethod
         def run(cls, parser, args):
-            def filter(issue, name):
-                a = issue[name]
+            def filter_issue(name, issue):
+                a = issue.get(name)
                 if a and a['login'] == config.username:
                     return True
+            has_user = partial(filter_issue, 'user')
+            has_assignee = partial(filter_issue, 'assignee')
             state = 'closed' if args.closed else 'open'
             issues = req.get(cls.url(), state=state)
             if not issues:
                 return
             if args.created_by_me and args.assigned_to_me:
-                issues = [
-                        i for i in issues
-                        if list(filter(i, 'assignee'))
-                        or list(filter(i, 'user'))]
+                issues = filter(lambda i: has_user(i) or has_assignee(i), issues)
             elif args.created_by_me:
-                issues = [
-                        i for i in issues if list(filter(i, 'user'))]
+                issues = filter(has_user, issues)
             elif args.assigned_to_me:
-                issues = [i for i in issues if list(filter(i, 'assignee'))]
+                issues = filter(has_assignee, issues)
             for issue in issues:
                 cls.print_issue_summary(issue)
 

--- a/git-hub
+++ b/git-hub
@@ -523,25 +523,20 @@ def check_empty_message(msg):
     return msg
 
 message_markdown_help = '''\
-# Remember GitHub will parse comments and descriptions as GitHub
-# Flavored Markdown.
-# For details see:
-# https://help.github.com/articles/github-flavored-markdown/
-#
-# Lines starting with '# ' (note the space after the hash!) will be
-# ignored, and an empty message aborts the command. The space after the
-# hash is required by comments to avoid accidentally commenting out a
-# line starting with a reference to an issue (#4 for example). If you
-# want to include Markdown headers in your message, use the Setext-style
-# headers, which consist on underlining titles with '=' for first-level
-# or '-' for second-level headers.
+#-# Remember GitHub will parse comments and descriptions as GitHub
+#-# Flavored Markdown.
+#-# For details see:
+#-# https://help.github.com/articles/github-flavored-markdown/
+#-#
+#-# Lines starting with '#-#' will be ignored, and an empty message
+#-# aborts the command.
 '''
 
 # For now it only removes comment lines
 def clean_message(msg):
     lines = msg.splitlines()
     # Remove comment lines
-    lines = [l for l in lines if not l.startswith('# ') and l != '#']
+    lines = [l for l in lines if not l.startswith('#-#')]
     return '\n'.join(lines)
 
 # For messages expecting a title, split the first line as the title and the
@@ -994,22 +989,22 @@ class IssueUtil (object):
     gh_path = 'issues'
     id_var = 'ISSUE'
     help_msg = '''
-# Please enter the title and description below.
-#
-# The first line is interpreted as the title. An optional description
-# can follow after an empty line.
-#
-# Example:
-#
-#   Some title
-#
-#   Some description that can span several
-#   lines.
-#
+#-# Please enter the title and description below.
+#-#
+#-# The first line is interpreted as the title. An optional description
+#-# can follow after an empty line.
+#-#
+#-# Example:
+#-#
+#-#   Some title
+#-#
+#-#   Some description that can span several
+#-#   lines.
+#-#
 ''' + message_markdown_help
     comment_help_msg = '''
-# Please enter your comment below.
-#
+#-# Please enter your comment below.
+#-#
 ''' + message_markdown_help
 
     @classmethod

--- a/man.rst
+++ b/man.rst
@@ -171,6 +171,14 @@ COMMANDS
   `new`
     Create a new issue.
 
+    The content of the template files **ISSUE_TEMPLATE** or
+    **ISSUE_TEMPLATE.md** will be added to the issue message if any of those
+    template files is found in the top-level directory of the project, the
+    **.github** directory or the **.git** directory.
+    The order for template files lookups matters and it follows the order
+    as described above for template file names and directories. And only the
+    content of the first template found will be added.
+
     \-m MSG, --message=MSG
       Issue title (and description). The first line is used as the issue title
       and any text after an empty line is used as the optional body.  If this
@@ -185,6 +193,9 @@ COMMANDS
 
     \-M ID, --milestone=ID
       Assign the milestone identified by the number ID to the issue.
+
+    \--no-template
+      Do not add the template content to the message.
 
   `update` ISSUE
     Similar to `new` but update an existing issue identified by **ISSUE**.
@@ -274,6 +285,14 @@ COMMANDS
     The repository to issue the pull request from is taken from the
     `hub.forkrepo` configuration, which defaults to
     *hub.username/<hub.upstream project part>*.
+
+    The content of the template files **PULL_REQUEST_TEMPLATE** or
+    **PULL_REQUEST_TEMPLATE.md** will be added to the pull request message
+    if any of those template files is found in the top-level directory of
+    the project, the **.github** directory or the **.git** directory.
+    The order for template files lookups matters and it follows the order
+    as described above for template file names and directories. And only the
+    content of the first template found will be added.
 
     \-m MSG, --message=MSG
       Pull request title (and description). The first line is used as the pull

--- a/relnotes/comments.migration.md
+++ b/relnotes/comments.migration.md
@@ -1,0 +1,4 @@
+### Use `#-#` for comments instead of `#`
+
+The symbol `#` at the start of a line is a header tag in Markdown and `#-#`should be used instead for comments. The syntax of the new comment header does not look esthetically good and it is not intended for practical use but it will avoid mangling markdown or any other markup language.
+If you have any script that creates new issues, PRs or comments then they will need to be updated to the new comment header.

--- a/relnotes/templates.feature.md
+++ b/relnotes/templates.feature.md
@@ -1,0 +1,24 @@
+### Support issue and pull request templates
+
+* The commands `git-hub issue new` and `git-hub pull new` add template
+contents to the issue or pull request message respectively.
+
+Looks for a template file in the root directory of the project,
+the `.github` directory and the `.git` directory until the first
+template file is found. Then reads the content from the template
+file found and adds it to the message of the issue or pull request.
+
+The supported file names for issue templates are `ISSUE_TEMPLATE`
+and `ISSUE_TEMPLATE.md`, and for pull request templates are
+`PULL_REQUEST_TEMPLATE` and `PULL_REQUEST_TEMPLATE.md`.
+The order for template lookups matters meaning that a template
+file name without extension is looked up first followed by the
+template file name with extension `.md`.
+
+Note that only the content of the first issue or pull request
+template found is added to the message of the issue or pull request
+respectively.
+
+Finally the commands `git-hub issue new` and `git-hub pull new`
+also accept `--no-template` to skip adding the template content
+to the issue or pull request message respectively.


### PR DESCRIPTION
TEST: Example pull request template.

The pull request addresses:

- [] Add a pull request template file
- [] Read the content of the template into a string
- [] Join the template to the body of the pull request

The commands `git-hub issue new` and `git-hub pull new` add template
contents to the issue or pull request message respectively.

Looks for a template file in the root directory of the project,
the `.github` directory and the `.git` directory until the first
template file is found. Then reads the content from the template
file found and adds it to the message of the issue or pull request.

The supported file names for issue templates are `ISSUE_TEMPLATE`
and `ISSUE_TEMPLATE.md`, and for pull request templates are
`PULL_REQUEST_TEMPLATE` and `PULL_REQUEST_TEMPLATE.md`.
The order for template lookups matters meaning that a template
file name without extension is looked up first followed by the
template file name with extension `.md`.

Note that only the content of the first issue or pull request
template found is added to the message of the issue or pull request
respectively.

Finally the commands `git-hub issue new` and `git-hub pull new`
also accept `--no-template` to skip adding template contents to
the issue or pull request message respectively.